### PR TITLE
feat: provision primary ENI separately from instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_ips\_count | Count of additional EIPs | `number` | `0` | no |
+| additional\_private\_ips | List of private IPs to attach to the private ENI | `list(string)` | `[]` | no |
+| additional\_private\_ips\_count | Count of additional private IPs | `number` | `0` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | allowed\_ports | List of allowed ingress TCP ports | `list(number)` | `[]` | no |
 | allowed\_ports\_udp | List of allowed ingress UDP ports | `list(number)` | `[]` | no |
@@ -211,6 +213,7 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | additional\_eni\_ids | Map of ENI to EIP |
+| additional\_private\_eni\_ids | Map of ENI to EIP |
 | alarm | CloudWatch Alarm ID |
 | arn | ARN of the instance |
 | ebs\_ids | IDs of EBSs |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,6 +19,8 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_ips\_count | Count of additional EIPs | `number` | `0` | no |
+| additional\_private\_ips | List of private IPs to attach to the private ENI | `list(string)` | `[]` | no |
+| additional\_private\_ips\_count | Count of additional private IPs | `number` | `0` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | allowed\_ports | List of allowed ingress TCP ports | `list(number)` | `[]` | no |
 | allowed\_ports\_udp | List of allowed ingress UDP ports | `list(number)` | `[]` | no |
@@ -81,6 +83,7 @@
 | Name | Description |
 |------|-------------|
 | additional\_eni\_ids | Map of ENI to EIP |
+| additional\_private\_eni\_ids | Map of ENI to EIP |
 | alarm | CloudWatch Alarm ID |
 | arn | ARN of the instance |
 | ebs\_ids | IDs of EBSs |

--- a/eni.tf
+++ b/eni.tf
@@ -50,3 +50,23 @@ resource "aws_network_interface" "additional_private" {
 
   tags = module.this.tags
 }
+
+resource "aws_network_interface" "primary" {
+  subnet_id  = var.subnet
+  private_ip = var.private_ip
+
+  ipv6_address_count = var.ipv6_address_count < 0 ? null : var.ipv6_address_count
+  ipv6_addresses     = length(var.ipv6_addresses) == 0 ? null : var.ipv6_addresses
+  source_dest_check  = var.source_dest_check
+
+  security_groups = compact(
+    concat(
+      [
+        var.create_default_security_group ? join("", aws_security_group.default.*.id) : ""
+      ],
+      var.security_groups
+    )
+  )
+
+  tags = module.this.tags
+}

--- a/main.tf
+++ b/main.tf
@@ -99,38 +99,29 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_instance" "default" {
-  count                       = local.instance_count
-  ami                         = local.ami
-  availability_zone           = local.availability_zone
-  instance_type               = var.instance_type
-  ebs_optimized               = var.ebs_optimized
-  disable_api_termination     = var.disable_api_termination
-  user_data                   = var.user_data
-  user_data_base64            = var.user_data_base64
-  iam_instance_profile        = local.instance_profile
-  associate_public_ip_address = var.associate_public_ip_address
-  key_name                    = var.ssh_key_pair
-  subnet_id                   = var.subnet
-  monitoring                  = var.monitoring
-  private_ip                  = var.private_ip
-  source_dest_check           = var.source_dest_check
-  ipv6_address_count          = var.ipv6_address_count < 0 ? null : var.ipv6_address_count
-  ipv6_addresses              = length(var.ipv6_addresses) == 0 ? null : var.ipv6_addresses
-
-  vpc_security_group_ids = compact(
-    concat(
-      [
-        var.create_default_security_group ? join("", aws_security_group.default.*.id) : "",
-      ],
-      var.security_groups
-    )
-  )
+  count                   = local.instance_count
+  ami                     = local.ami
+  availability_zone       = local.availability_zone
+  instance_type           = var.instance_type
+  ebs_optimized           = var.ebs_optimized
+  disable_api_termination = var.disable_api_termination
+  user_data               = var.user_data
+  user_data_base64        = var.user_data_base64
+  iam_instance_profile    = local.instance_profile
+  key_name                = var.ssh_key_pair
+  monitoring              = var.monitoring
 
   root_block_device {
     volume_type           = local.root_volume_type
     volume_size           = var.root_volume_size
     iops                  = local.root_iops
     delete_on_termination = var.delete_on_termination
+  }
+
+  network_interface {
+    device_index          = 0
+    network_interface_id  = aws_network_interface.primary.id
+    delete_on_termination = false
   }
 
   tags = module.this.tags


### PR DESCRIPTION
## what
* Provision the instance's primary ENI separately from the instance

## why
* Making a change that rebuilds the instance will not rebuild the ENI
    * This will retain the private IP for machines that don't use static IPs

